### PR TITLE
new link for documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,16 +19,17 @@
         <div class="navbar-collapse collapse" id="navbar-main">
           <ul class="nav navbar-nav navbar-right">
             <li>
-              <a href="https://github.com/cmv/cmv-docs/">Documentation</a>
+              <a href="http://docs.cmv.io/">Documentation</a>
             </li>
             <li>
               <a href="https://gis.stackexchange.com/questions/tagged/cmv">Support</a>
             </li>
-            <li>
+            <!-- <li>
               <a href="#">Examples</a>
             </li>
+            -->
             <li>
-              <a href="https://github.com/cmv/cmv-contrib-widgets">Widgets</a>
+              <a href="https://github.com/cmv/cmv-contrib-widgets">Contributed Widgets</a>
             </li>
             <li>
               <a href="http://demo.cmv.io/viewer/">Demo</a>


### PR DESCRIPTION
1. Change documentation link to new home for CMV documentation.
2. Remove examples link for now since there are none.
3. Change "Widgets" link to "Contributed Widgets" to reflect the
   destination.
